### PR TITLE
Net48 compatibility

### DIFF
--- a/src/HeboTech.ATLib.TestConsole/HeboTech.ATLib.TestConsole.csproj
+++ b/src/HeboTech.ATLib.TestConsole/HeboTech.ATLib.TestConsole.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HeboTech.ATLib.TestConsole/HeboTech.ATLib.TestConsole.csproj
+++ b/src/HeboTech.ATLib.TestConsole/HeboTech.ATLib.TestConsole.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HeboTech.ATLib.Tests/HeboTech.ATLib.Tests.csproj
+++ b/src/HeboTech.ATLib.Tests/HeboTech.ATLib.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-
+    <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/HeboTech.ATLib.Tests/HeboTech.ATLib.Tests.csproj
+++ b/src/HeboTech.ATLib.Tests/HeboTech.ATLib.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HeboTech.ATLib.Tests/PDU/PduTests.cs
+++ b/src/HeboTech.ATLib.Tests/PDU/PduTests.cs
@@ -1,4 +1,5 @@
-﻿using HeboTech.ATLib.CodingSchemes;
+﻿using System;
+using HeboTech.ATLib.CodingSchemes;
 using HeboTech.ATLib.DTOs;
 using HeboTech.ATLib.PDU;
 using Xunit;
@@ -23,7 +24,7 @@ namespace HeboTech.ATLib.Tests.PDU
         [InlineData("07911326040000F0040B911346610089F60000208062917314800CC8F71D14969741F977FD07", "31624000000", "31641600986", "02-08-26-19-37-41-+02", "How are you?")]
         public void Decode_SmsDeliver_tests(string data, string serviceCenterNumber, string senderNumber, string timestamp, string message)
         {
-            SmsDeliver pduMessage = Pdu.DecodeSmsDeliver(data);
+            SmsDeliver pduMessage = Pdu.DecodeSmsDeliver(data.AsSpan());
 
             Assert.NotNull(pduMessage);
             Assert.Equal(TypeOfNumber.International, pduMessage.ServiceCenterNumber.Ton);
@@ -39,7 +40,7 @@ namespace HeboTech.ATLib.Tests.PDU
         [InlineData("0011000802231537180000AA0D5062154403D1CB68D03DED06", "", "32517381", "PDU 4 teh win")]
         public void Decode_SmsSubmit_tests(string data, string serviceCenterNumber, string senderNumber, string message)
         {
-            SmsSubmit pduMessage = Pdu.DecodeSmsSubmit(data);
+            SmsSubmit pduMessage = Pdu.DecodeSmsSubmit(data.AsSpan());
 
             Assert.NotNull(pduMessage);
             Assert.Equal(serviceCenterNumber, pduMessage.ServiceCenterNumber?.Number ?? "");

--- a/src/HeboTech.ATLib.Tests/Parsers/AtReaderTests.cs
+++ b/src/HeboTech.ATLib.Tests/Parsers/AtReaderTests.cs
@@ -16,7 +16,7 @@ namespace HeboTech.ATLib.Tests.Parsers
 
             string input = "Line1\r\nLine2\r\nLine3\r\n";
             byte[] buffer = Encoding.UTF8.GetBytes(input);
-            stream.Write(buffer);
+            stream.Write(buffer, 0, buffer.Length); 
             stream.Position = 0;
 
             dut.Open();
@@ -40,7 +40,7 @@ namespace HeboTech.ATLib.Tests.Parsers
 
             string input = "Line1\r\nLine2\r\n> Line3\r\n";
             byte[] buffer = Encoding.UTF8.GetBytes(input);
-            stream.Write(buffer);
+            stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
 
             dut.Open();
@@ -66,7 +66,7 @@ namespace HeboTech.ATLib.Tests.Parsers
 
             string input = "\r\n\r\n\r\n";
             byte[] buffer = Encoding.UTF8.GetBytes(input);
-            stream.Write(buffer);
+            stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
 
             dut.Open();
@@ -90,7 +90,7 @@ namespace HeboTech.ATLib.Tests.Parsers
 
             string input = "+CME ERROR: ErrorMessage\r\n";
             byte[] buffer = Encoding.UTF8.GetBytes(input);
-            stream.Write(buffer);
+            stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
 
             dut.Open();
@@ -110,7 +110,7 @@ namespace HeboTech.ATLib.Tests.Parsers
 
             string input = "RING\r\n\r\nRING\r\n\r\nMISSED_CALL: 01:23PM 12345678\r\n";
             byte[] buffer = Encoding.UTF8.GetBytes(input);
-            stream.Write(buffer);
+            stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
 
             dut.Open();

--- a/src/HeboTech.ATLib/DTOs/PhoneNumber.cs
+++ b/src/HeboTech.ATLib/DTOs/PhoneNumber.cs
@@ -4,7 +4,7 @@
     {
         public PhoneNumber(string number)
         {
-            if (number.StartsWith('+'))
+            if (number.StartsWith("+"))
             {
                 Ton = TypeOfNumber.International;
                 Npi = NumberPlanIdentification.ISDN;

--- a/src/HeboTech.ATLib/DTOs/SupportedPreferredMessageStorages.cs
+++ b/src/HeboTech.ATLib/DTOs/SupportedPreferredMessageStorages.cs
@@ -19,9 +19,9 @@ namespace HeboTech.ATLib.DTOs
         public override string ToString()
         {
             return
-                $"Storage1: {string.Join(',', Storage1)}{Environment.NewLine}" +
-                $"Storage2: {string.Join(',', Storage2)}{Environment.NewLine}" +
-                $"Storage3: {string.Join(',', Storage3)}";
+                $"Storage1: {string.Join(",", Storage1)}{Environment.NewLine}" +
+                $"Storage2: {string.Join(",", Storage2)}{Environment.NewLine}" +
+                $"Storage3: {string.Join(",", Storage3)}";
         }
     }
 }

--- a/src/HeboTech.ATLib/Events/MissedCallEventArgs.cs
+++ b/src/HeboTech.ATLib/Events/MissedCallEventArgs.cs
@@ -13,7 +13,7 @@
 
         public static MissedCallEventArgs CreateFromResponse(string response)
         {
-            string[] split = response.Split(' ', 3);
+            string[] split = response.Split(new []{ ' ' }, 3);
             return new MissedCallEventArgs(split[1], split[2]);
         }
     }

--- a/src/HeboTech.ATLib/HeboTech.ATLib.csproj
+++ b/src/HeboTech.ATLib/HeboTech.ATLib.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--<TargetFramework>netstandard2.1</TargetFramework>-->
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
     <Authors>HeboTech</Authors>
     <Product>HeboTech ATLib</Product>
     <Version>4.1.0</Version>

--- a/src/HeboTech.ATLib/HeboTech.ATLib.csproj
+++ b/src/HeboTech.ATLib/HeboTech.ATLib.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <!--<TargetFramework>netstandard2.1</TargetFramework>-->
+    <TargetFramework>net48</TargetFramework>
     <Authors>HeboTech</Authors>
     <Product>HeboTech ATLib</Product>
     <Version>4.1.0</Version>
@@ -15,11 +16,17 @@
     <PackageReleaseNotes>https://github.com/hbjorgo/ATLib/releases</PackageReleaseNotes>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <FileVersion>4.1.0.0</FileVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Net.Compilers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/HeboTech.ATLib/Helpers/CollectionsExtensions.cs
+++ b/src/HeboTech.ATLib/Helpers/CollectionsExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace HeboTech.ATLib.Helpers
+{
+
+    public static class CollectionsExtensions
+    {
+        public static T[] Sub<T>(this T[] self, int start, int end)
+        {
+            var length = end - start;
+            T[] result = new T[length];
+            Array.Copy(self, start, result, 0, length);
+            return result;
+        }
+        public static ReadOnlySpan<T> Sub<T>(this ReadOnlySpan<T> self, int start, int end)
+        {
+            return self.Slice(start, end - start);
+        }
+
+        public static ReadOnlySpan<T> Sub<T>(this ReadOnlySpan<T> self, int start) => self.Sub(start, self.Length);
+    }
+    
+}

--- a/src/HeboTech.ATLib/Modems/SIMCOM/SIM5320.cs
+++ b/src/HeboTech.ATLib/Modems/SIMCOM/SIM5320.cs
@@ -65,7 +65,7 @@ namespace HeboTech.ATLib.Modems.SIMCOM
                             string alphabet = line1Match.Groups["alphabet"].Value;
                             int length = int.Parse(line1Match.Groups["length"].Value);
                             string pdu = line2Match.Groups["pdu"].Value;
-                            SmsDeliver pduMessage = Pdu.DecodeSmsDeliver(pdu);
+                            SmsDeliver pduMessage = Pdu.DecodeSmsDeliver(pdu.AsSpan());
                             return ModemResponse.ResultSuccess(new Sms((SmsStatus)status, pduMessage.SenderNumber, pduMessage.Timestamp, pduMessage.Message));
                         }
                     }

--- a/src/HeboTech.ATLib/PDU/Pdu.cs
+++ b/src/HeboTech.ATLib/PDU/Pdu.cs
@@ -3,6 +3,7 @@ using HeboTech.ATLib.DTOs;
 using System;
 using System.Globalization;
 using System.Text;
+using HeboTech.ATLib.Helpers;
 
 namespace HeboTech.ATLib.PDU
 {
@@ -50,15 +51,15 @@ namespace HeboTech.ATLib.PDU
             int offset = 0;
 
             // SMSC information
-            byte smsc_length = HexToByte(text[offset..(offset += 2)]);
+            byte smsc_length = HexToByte(text.Sub(offset, (offset += 2)));
             PhoneNumber serviceCenterNumber = null;
             if (smsc_length > 0)
             {
-                serviceCenterNumber = DecodePhoneNumber(text[offset..(offset += smsc_length * 2)]);
+                serviceCenterNumber = DecodePhoneNumber(text.Sub(offset, (offset += smsc_length * 2)));
             }
 
             // SMS-DELIVER start
-            byte header = HexToByte(text[offset..(offset += 2)]);
+            byte header = HexToByte(text.Sub(offset, (offset += 2)));
 
             int tp_mti = header & 0b0000_0011;
             if (tp_mti != (byte)PduType.SMS_DELIVER)
@@ -67,21 +68,21 @@ namespace HeboTech.ATLib.PDU
             int tp_mms = header & 0b0000_0100;
             int tp_rp = header & 0b1000_0000;
 
-            byte tp_oa_length = HexToByte(text[offset..(offset += 2)]);
+            byte tp_oa_length = HexToByte(text.Sub(offset, (offset += 2)));
             tp_oa_length = (byte)(tp_oa_length % 2 == 0 ? tp_oa_length : tp_oa_length + 1);
             PhoneNumber oa = null;
             if (tp_oa_length > 0)
             {
                 int oa_digits = tp_oa_length + 2; // Add 2 for TON
-                oa = DecodePhoneNumber(text[offset..(offset += oa_digits)]);
+                oa = DecodePhoneNumber(text.Sub(offset, (offset += oa_digits)));
             }
-            byte tp_pid = HexToByte(text[offset..(offset += 2)]);
-            byte tp_dcs = HexToByte(text[offset..(offset += 2)]);
-            ReadOnlySpan<char> tp_scts = text[offset..(offset += 14)];
-            byte tp_udl = HexToByte(text[offset..(offset += 2)]);
+            byte tp_pid = HexToByte(text.Sub(offset, (offset += 2)));
+            byte tp_dcs = HexToByte(text.Sub(offset, (offset += 2)));
+            ReadOnlySpan<char> tp_scts = text.Sub(offset, (offset += 14));
+            byte tp_udl = HexToByte(text.Sub(offset, (offset += 2)));
             int udlBytes = (int)Math.Ceiling(tp_udl * 7 / 8.0);
 
-            ReadOnlySpan<char> tp_ud = text[offset..(offset += ((udlBytes) * 2))];
+            ReadOnlySpan<char> tp_ud = text.Sub(offset, (offset += ((udlBytes) * 2)));
             string message = null;
             switch (tp_dcs)
             {
@@ -100,15 +101,15 @@ namespace HeboTech.ATLib.PDU
             int offset = 0;
 
             // SMSC information
-            byte smsc_length = HexToByte(text[offset..(offset += 2)]);
+            byte smsc_length = HexToByte(text.Sub(offset, (offset += 2)));
             PhoneNumber serviceCenterNumber = null;
             if (smsc_length > 0)
             {
-                serviceCenterNumber = DecodePhoneNumber(text[offset..(offset += smsc_length * 2)]);
+                serviceCenterNumber = DecodePhoneNumber(text.Sub(offset, (offset += smsc_length * 2)));
             }
 
             // SMS-DELIVER start
-            byte header = HexToByte(text[offset..(offset += 2)]);
+            byte header = HexToByte(text.Sub(offset, (offset += 2)));
 
             int tp_mti = header & 0b0000_0011;
             if (tp_mti != (byte)PduType.SMS_SUBMIT)
@@ -118,34 +119,34 @@ namespace HeboTech.ATLib.PDU
             int tp_vpf = header & 0b0001_1000;
             int tp_rp = header & 0b1000_0000;
 
-            byte tp_mr = HexToByte(text[offset..(offset += 2)]);
-            byte tp_oa_length = HexToByte(text[offset..(offset += 2)]);
+            byte tp_mr = HexToByte(text.Sub(offset, (offset += 2)));
+            byte tp_oa_length = HexToByte(text.Sub(offset, (offset += 2)));
             tp_oa_length = (byte)(tp_oa_length % 2 == 0 ? tp_oa_length : tp_oa_length + 1);
             PhoneNumber oa = null;
             if (tp_oa_length > 0)
             {
                 int oa_digits = tp_oa_length + 2; // Add 2 for TON
-                oa = DecodePhoneNumber(text[offset..(offset += oa_digits)]);
+                oa = DecodePhoneNumber(text.Sub(offset, (offset += oa_digits)));
             }
-            byte tp_pid = HexToByte(text[offset..(offset += 2)]);
-            byte tp_dcs = HexToByte(text[offset..(offset += 2)]);
+            byte tp_pid = HexToByte(text.Sub(offset, (offset += 2)));
+            byte tp_dcs = HexToByte(text.Sub(offset, (offset += 2)));
             byte tp_vp = 0;
             if (tp_vpf == 0x00)
-                tp_vp = HexToByte(text[offset..(offset += 0)]);
+                tp_vp = HexToByte(text.Sub(offset, (offset += 0)));
             else if (tp_vpf == 0x01)
-                tp_vp = HexToByte(text[offset..(offset += 14)]);
+                tp_vp = HexToByte(text.Sub(offset, (offset += 14)));
             else if (tp_vpf == 0x10)
-                tp_vp = HexToByte(text[offset..(offset += 2)]);
+                tp_vp = HexToByte(text.Sub(offset, (offset += 2)));
             else if (tp_vpf == 0x11)
-                tp_vp = HexToByte(text[offset..(offset += 14)]);
-            byte tp_udl = HexToByte(text[offset..(offset += 2)]);
+                tp_vp = HexToByte(text.Sub(offset, (offset += 14)));
+            byte tp_udl = HexToByte(text.Sub(offset, (offset += 2)));
 
             string message = null;
             switch (tp_dcs)
             {
                 case 0x00:
                     int length = (tp_udl * 7 / 8) + 1;
-                    ReadOnlySpan<char> tp_ud = text[offset..(offset += ((length) * 2))];
+                    ReadOnlySpan<char> tp_ud = text.Sub(offset, (offset += ((length) * 2)));
                     message = Gsm7.Decode(new string(tp_ud.ToArray()));
                     break;
                 default:
@@ -168,8 +169,8 @@ namespace HeboTech.ATLib.PDU
                 swappedData[i] = data[i + 1];
                 swappedData[i + 1] = data[i];
             }
-            if (swappedData[^1] == 'F')
-                return swappedData[..^1];
+            if (swappedData[swappedData.Length - 1] == 'F')
+                return swappedData.Sub(0, swappedData.Length - 1);
             return swappedData;
         }
 
@@ -182,8 +183,8 @@ namespace HeboTech.ATLib.PDU
         {
             if (data.Length < 4)
                 return default;
-            TypeOfNumber ton = (TypeOfNumber)((HexToByte(data[0..2]) & 0b0111_0000) >> 4);
-            string number = new String(SwapPhoneNumberDigits(data[2..]));
+            TypeOfNumber ton = (TypeOfNumber)((HexToByte(data.Sub(0, 2)) & 0b0111_0000) >> 4);
+            string number = new String(SwapPhoneNumberDigits(data.Sub(2)));
             return new PhoneNumber(
                 number,
                 ton,
@@ -200,17 +201,17 @@ namespace HeboTech.ATLib.PDU
             }
             ReadOnlySpan<char> swappedSpan = swappedData;
 
-            byte offset = DecimalToByte(swappedSpan[12..14]);
+            byte offset = DecimalToByte(swappedSpan.Sub(12, 14));
             bool positive = (offset & (1 << 7)) == 0;
             byte offsetQuarters = (byte)(offset & 0b0111_1111);
 
             DateTimeOffset timestamp = new DateTimeOffset(
-                DecimalToByte(swappedSpan[..2]) + timestampYearOffset,
-                DecimalToByte(swappedSpan[2..4]),
-                DecimalToByte(swappedSpan[4..6]),
-                DecimalToByte(swappedSpan[6..8]),
-                DecimalToByte(swappedSpan[8..10]),
-                DecimalToByte(swappedSpan[10..12]),
+                DecimalToByte(swappedSpan.Sub(0, 2)) + timestampYearOffset,
+                DecimalToByte(swappedSpan.Sub(2, 4)),
+                DecimalToByte(swappedSpan.Sub(4, 6)),
+                DecimalToByte(swappedSpan.Sub(6, 8)),
+                DecimalToByte(swappedSpan.Sub(8, 10)),
+                DecimalToByte(swappedSpan.Sub(10, 12)),
                 TimeSpan.FromMinutes(offsetQuarters * 15)); // Offset in quarter of hours
             return timestamp;
 

--- a/src/HeboTech.ATLib/PDU/Pdu.cs
+++ b/src/HeboTech.ATLib/PDU/Pdu.cs
@@ -23,7 +23,7 @@ namespace HeboTech.ATLib.PDU
             // Type-of-Address
             sb.Append(GetAddressType(phoneNumber).ToString("X2"));
             // Phone number in semi octets. 12345678 is represented as 21436587
-            sb.Append(SwapPhoneNumberDigits(phoneNumber.ToString()));
+            sb.Append(SwapPhoneNumberDigits(phoneNumber.ToString().AsSpan()));
             // TP-PID Protocol identifier
             sb.Append("00");
             // TP-DCS Data Coding Scheme. '00'-7bit default alphabet. '04'-8bit
@@ -86,7 +86,7 @@ namespace HeboTech.ATLib.PDU
             switch (tp_dcs)
             {
                 case 0x00:
-                    message = Gsm7.Decode(new string(tp_ud));
+                    message = Gsm7.Decode(new string(tp_ud.ToArray()));
                     break;
                 default:
                     break;
@@ -146,7 +146,7 @@ namespace HeboTech.ATLib.PDU
                 case 0x00:
                     int length = (tp_udl * 7 / 8) + 1;
                     ReadOnlySpan<char> tp_ud = text[offset..(offset += ((length) * 2))];
-                    message = Gsm7.Decode(new string(tp_ud));
+                    message = Gsm7.Decode(new string(tp_ud.ToArray()));
                     break;
                 default:
                     break;
@@ -156,7 +156,7 @@ namespace HeboTech.ATLib.PDU
 
         private static byte HexToByte(ReadOnlySpan<char> text)
         {
-            byte retVal = (byte)int.Parse(text, NumberStyles.HexNumber);
+            byte retVal = (byte)int.Parse(text.ToString(), NumberStyles.HexNumber);
             return retVal;
         }
 
@@ -214,10 +214,11 @@ namespace HeboTech.ATLib.PDU
                 TimeSpan.FromMinutes(offsetQuarters * 15)); // Offset in quarter of hours
             return timestamp;
 
-            static byte DecimalToByte(ReadOnlySpan<char> text)
-            {
-                return (byte)int.Parse(text, NumberStyles.Integer);
-            }
+        }
+
+        private static byte DecimalToByte(ReadOnlySpan<char> text)
+        {
+            return (byte)int.Parse(text.ToString(), NumberStyles.Integer);
         }
     }
 }

--- a/src/HeboTech.ATLib/Parsers/AtReader.cs
+++ b/src/HeboTech.ATLib/Parsers/AtReader.cs
@@ -145,7 +145,7 @@ namespace HeboTech.ATLib.Parsers
                         break;
                 }
             }
-            slice = sequence.Slice(0, i - delimiter.Length);
+            slice = sequence.Slice(0, Math.Max(0, i - delimiter.Length));
             
             if (i == sequence.Length && d != delimiter.Length)
                 return -1;


### PR DESCRIPTION
Hello,
I needed a AT command library for a net48 project, so i decided to make ATLib compatible with this target.

I add to replace all ranges and indexes by "classical" code to make it compile with both 4.8 and 2.1.
I also add to replace some Sequence methods by custom code and implicit operators by explicit calls or code modifications.

Could you please take a look at my job ?
Don't hesitate if you have any question/suggestion !